### PR TITLE
fine tuning

### DIFF
--- a/salt/functions/ConnectSqlConnection.ps1
+++ b/salt/functions/ConnectSqlConnection.ps1
@@ -15,7 +15,8 @@ Connect-SqlConnection -ConnectionString "Server=.;Integrated Security=True"
     (
         [string]
         [ValidateNotNullorEmpty()]
-        $ConnectionString
+        $ConnectionString,
+        [Switch] $IgnoreCheck
     )
     $sqlConnection = New-Object System.Data.SqlClient.SqlConnection $ConnectionString        
     try {
@@ -36,14 +37,19 @@ Connect-SqlConnection -ConnectionString "Server=.;Integrated Security=True"
         Write-Error $_.Exception
         Throw
     }
-    $JobServerExists = Test-SQLServerAgentService  -SmoObjectConnection $SqlSvr
-    if ($JobServerExists -eq 1) {
-        Write-Host "SQL Server Agent Job Service on $($SqlSvr.JobServer.Name) Is Up And Running!" -ForegroundColor White -BackgroundColor DarkCyan
-        return $SqlSvr
+    if (!$IgnoreCheck) {
+        $JobServerExists = Test-SQLServerAgentService  -SmoObjectConnection $SqlSvr
+        if ($JobServerExists -eq 1) {
+            Write-Host "SQL Server Agent Job Service on $($SqlSvr.JobServer.Name) Is Up And Running!" -ForegroundColor White -BackgroundColor DarkCyan
+            return $SqlSvr
+        }
+        else {
+            Write-Error "Check that the Agent Service is running on $($sqlSvr.JobServer) and try again."
+            Throw
+        }
     }
     else {
-        Write-Error "Check that the Agent Service is running on $($sqlSvr.JobServer) and try again."
-        Throw
+        return $SqlSvr
     }
 }
    

--- a/salt/functions/SetJobOperator.ps1
+++ b/salt/functions/SetJobOperator.ps1
@@ -25,6 +25,11 @@ Set-JobOperator -SqlServer $SqlConnection -root $x
         $root
     )
     $JobOperatorName = $root.Operator.Name
+    if ($JobOperatorName.Length -eq 0)
+    {
+        Write-Verbose "No Operator Info in XML" -Verbose
+        Return
+    }
     $JobOperatorEMail = $root.Operator.EMail
     $JobOperatorPage = $root.Operator.Page
     $JobOperatorNetSend = $root.Operator.NetSend


### PR DESCRIPTION
sql connection now has override to ignore check against master database; if job operator name is blank then do not continue as no operator to create; job schedules are not dropped and re-created - only drop those that are not in xml, and create/alter as required.